### PR TITLE
Standalone with stdlib (Recommended)

### DIFF
--- a/lib/bazaar.rb
+++ b/lib/bazaar.rb
@@ -2,22 +2,22 @@ require "bazaar/version"
 
 module Bazaar
   def self.item
-    get_item("items").humanize
+    get_item("items").capitalize
   end
   def self.adj
-    get_item("adj").humanize
+    get_item("adj").capitalize
   end
   def self.object
-    (get_item("adj") + ' ' + get_item("items")).humanize
+    (get_item("adj") + ' ' + get_item("items")).capitalize
   end
   def self.super_item
-    get_item("superitems").humanize
+    get_item("superitems").capitalize
   end
   def self.super_adj
-    get_item("superadj").humanize
+    get_item("superadj").capitalize
   end
   def self.super_object
-    (get_item("superadj") + ' ' + get_item("superitems")).humanize
+    (get_item("superadj") + ' ' + get_item("superitems")).capitalize
   end
   def self.heroku
     get_item("superadj") + '-' + get_item("superitems") + '-' + rand(0-9999).to_s

--- a/test/smoke_test.rb
+++ b/test/smoke_test.rb
@@ -1,0 +1,9 @@
+require 'minitest/autorun'
+$:.unshift File.expand_path '../../lib', __FILE__
+require 'bazaar'
+
+class TestBazaar < MiniTest::Unit::TestCase
+  def test_it_returns_something
+    assert_instance_of String, Bazaar.object
+  end
+end


### PR DESCRIPTION
As implemented, Bazaar has an implicit dependency on ActiveSupport, so it will not work outside of most environments besides Rails.

This limits usage to the `String#capitalize` instead of `ActiveSupport::CoreExt::String::Inflections#humanize` on which it now depends. I believe this solution is satisfactory, but if not, I will provide another option which will explicitly require active support in the gemspec and library so that it can still be used outside of Rails.
