### PR TITLE
Standalone with active support (Not Recommended)

### DIFF
--- a/bazaar.gemspec
+++ b/bazaar.gemspec
@@ -16,4 +16,6 @@ Gem::Specification.new do |gem|
   gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
+
+  gem.add_dependency 'activesupport'
 end

--- a/lib/bazaar.rb
+++ b/lib/bazaar.rb
@@ -1,4 +1,5 @@
 require "bazaar/version"
+require "active_support/core_ext/string/inflections"
 
 module Bazaar
   def self.item

--- a/test/smoke_test.rb
+++ b/test/smoke_test.rb
@@ -1,0 +1,9 @@
+require 'minitest/autorun'
+$:.unshift File.expand_path '../../lib', __FILE__
+require 'bazaar'
+
+class TestBazaar < MiniTest::Unit::TestCase
+  def test_it_returns_something
+    assert_instance_of String, Bazaar.object
+  end
+end


### PR DESCRIPTION
If for some reason, using the simple `String#capitalize` as detailsed in raycchan/bazaar#1 is not sufficient, this option at least explicitly names `ActiveSupport` as a dependency so that it can be installed and used outside of rails.
